### PR TITLE
github: new workflow for packaging

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,0 +1,26 @@
+name: Package
+
+on:
+  pull_request: {}
+  push: { branches: [main] }
+
+jobs:
+  package:
+    runs-on: macos-10.15
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14.x'
+    - run: npm ci
+    - run: npm run electron:build -- --mac --publish=never
+    - uses: actions/upload-artifact@v2
+      with:
+        name: rancher-desktop.dmg
+        path: dist/electron/rancher-desktop*.dmg
+    - uses: actions/upload-artifact@v2
+      with:
+        name: rancher-desktop-mac.zip
+        path: dist/electron/rancher-desktop*-mac.zip


### PR DESCRIPTION
This will run packaging for all PRs & main branch, so that we can download the built packages to test out.  This only builds the macos bits for now (because that's the only thing we _can_ build at this point).