### PR TITLE
Workflows: Package: Only test signing on push to main, tags.

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -133,6 +133,11 @@ jobs:
     name: Test Signing
     needs: package
     runs-on: windows-2022
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-')) ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) ||
+      (github.event_name == 'workflow_dispatch')
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
This limits the package signing checks to:
- pushes to main
- pushes to a release branch
- pushes to a tag
- manually invoked runs

This will hopefully reduce cycle time most of the time while still making sure we notice it failing.