### PR TITLE
Scripts: Split `npm run package` from `npm run build`.

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -53,7 +53,8 @@ jobs:
       if: matrix.arch == 'aarch64' && matrix.platform == 'mac'
       run: echo "M1=1" >> "${GITHUB_ENV}"
     - run: npm ci
-    - run: npm run build -- --${{ matrix.platform }} --publish=never
+    - run: npm run build
+    - run: npm run package -- --${{ matrix.platform }} --publish=never
     - name: Upload mac disk image
       uses: actions/upload-artifact@v3
       if: matrix.platform == 'mac'

--- a/.github/workflows/upgrade-generate.yaml
+++ b/.github/workflows/upgrade-generate.yaml
@@ -40,9 +40,8 @@ jobs:
       if: matrix.arch == 'aarch64' && matrix.platform == 'mac'
       run: echo "M1=1" >> "${GITHUB_ENV}"
     - run: npm ci
-    - run: npm run build -- --${{ matrix.platform }} --publish=never
-      env:
-        RD_FEAT_WIX: '1' # Will be optional soon
+    - run: npm run build
+    - run: npm run package -- --${{ matrix.platform }} --publish=never
     - name: Upload Windows exe installer
       if: runner.os == 'Windows'
       uses: actions/upload-artifact@v3

--- a/background.ts
+++ b/background.ts
@@ -134,7 +134,6 @@ Electron.app.whenReady().then(async() => {
   try {
     const commandLineArgs = getCommandLineArgs();
 
-    installDevtools();
     setupProtocolHandler();
 
     // Needs to happen before any file is written, otherwise that file
@@ -227,19 +226,6 @@ Electron.app.whenReady().then(async() => {
     Electron.app.quit();
   }
 });
-
-function installDevtools() {
-  if (Electron.app.isPackaged) {
-    return;
-  }
-
-  const { default: installExtension, VUEJS_DEVTOOLS } = require('electron-devtools-installer');
-
-  // No need to wait for it to complete, but handle any errors asynchronously
-  installExtension(VUEJS_DEVTOOLS).catch((err: any) => {
-    console.log(`Error installing VUEJS_DEVTOOLS: ${ err }`);
-  });
-}
 
 async function doFirstRunDialog() {
   if (settings.firstRunDialogNeeded()) {

--- a/background.ts
+++ b/background.ts
@@ -580,6 +580,10 @@ ipcMainProxy.on('k8s-progress', () => {
   window.send('k8s-progress', k8smanager.progress);
 });
 
+ipcMainProxy.handle('k8s-progress', () => {
+  return k8smanager.progress;
+});
+
 ipcMainProxy.handle('service-fetch', (_, namespace) => {
   return k8smanager.kubeBackend.listServices(namespace);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,6 @@
         "ejs": "3.1.8",
         "electron": "20.3.8",
         "electron-builder": "23.3.3",
-        "electron-devtools-installer": "3.2.0",
         "electron-notarize": "1.2.1",
         "eslint": "8.23.1",
         "eslint-import-resolver-typescript": "3.5.2",
@@ -15569,22 +15568,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/electron-devtools-installer": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rimraf": "^3.0.2",
-        "semver": "^7.2.1",
-        "tslib": "^2.1.0",
-        "unzip-crx-3": "^0.2.0"
-      }
-    },
-    "node_modules/electron-devtools-installer/node_modules/tslib": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "0BSD"
     },
     "node_modules/electron-notarize": {
       "version": "1.2.1",
@@ -31816,16 +31799,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/unzip-crx-3": {
-      "version": "0.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jszip": "^3.1.0",
-        "mkdirp": "^0.5.1",
-        "yaku": "^0.16.6"
-      }
-    },
     "node_modules/upath": {
       "version": "2.0.1",
       "license": "MIT",
@@ -34722,11 +34695,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yaku": {
-      "version": "0.16.7",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -45522,22 +45490,6 @@
         }
       }
     },
-    "electron-devtools-installer": {
-      "version": "3.2.0",
-      "dev": true,
-      "requires": {
-        "rimraf": "^3.0.2",
-        "semver": "^7.2.1",
-        "tslib": "^2.1.0",
-        "unzip-crx-3": "^0.2.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1",
-          "dev": true
-        }
-      }
-    },
     "electron-notarize": {
       "version": "1.2.1",
       "dev": true,
@@ -55885,15 +55837,6 @@
     "untildify": {
       "version": "4.0.0"
     },
-    "unzip-crx-3": {
-      "version": "0.2.0",
-      "dev": true,
-      "requires": {
-        "jszip": "^3.1.0",
-        "mkdirp": "^0.5.1",
-        "yaku": "^0.16.6"
-      }
-    },
     "upath": {
       "version": "2.0.1"
     },
@@ -57843,10 +57786,6 @@
     },
     "y18n": {
       "version": "5.0.8"
-    },
-    "yaku": {
-      "version": "0.16.7",
-      "dev": true
     },
     "yallist": {
       "version": "4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "http-proxy-middleware": "2.0.6",
         "https-proxy-agent": "5.0.1",
         "intl-messageformat": "10.2.5",
-        "jquery": "3.6.0",
+        "jquery": "3.6.3",
         "jsonpath": "1.1.1",
         "linux-ca": "2.0.1",
         "lodash": "4.17.21",
@@ -22737,8 +22737,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "3.6.0",
-      "license": "MIT"
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
+      "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg=="
     },
     "node_modules/js-base64": {
       "version": "2.6.4",
@@ -49914,7 +49915,9 @@
       "optional": true
     },
     "jquery": {
-      "version": "3.6.0"
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
+      "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg=="
     },
     "js-base64": {
       "version": "2.6.4"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint:go:nofix": "node scripts/ts-wrapper.js scripts/lint-go.ts",
     "generate:nerdctl-stub": "powershell scripts/windows/generate-nerdctl-stub.ps1",
     "build": "node scripts/ts-wrapper.js scripts/build.ts",
+    "package": "node scripts/ts-wrapper.js scripts/package.ts",
     "sign": "node scripts/ts-wrapper.js scripts/sign.ts",
     "wix": "node scripts/ts-wrapper.js scripts/wix.ts",
     "test": "npm run lint:nofix && npm run test:unit && npm run test:extra",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "ejs": "3.1.8",
     "electron": "20.3.8",
     "electron-builder": "23.3.3",
-    "electron-devtools-installer": "3.2.0",
     "electron-notarize": "1.2.1",
     "eslint": "8.23.1",
     "eslint-import-resolver-typescript": "3.5.2",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "http-proxy-middleware": "2.0.6",
     "https-proxy-agent": "5.0.1",
     "intl-messageformat": "10.2.5",
-    "jquery": "3.6.0",
+    "jquery": "3.6.3",
     "jsonpath": "1.1.1",
     "linux-ca": "2.0.1",
     "lodash": "4.17.21",

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -5,7 +5,7 @@ alpineLimaISO:
 WSLDistro: "0.32"
 kuberlr: 0.4.2
 helm: 3.11.0
-dockerCLI: 20.10.21
+dockerCLI: 20.10.23
 dockerBuildx: 0.10.0
 dockerCompose: 2.15.1
 trivy: 0.36.1

--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -1,7 +1,7 @@
 limaAndQemu: "1.29"
 alpineLimaISO:
-  isoVersion: 0.2.25.rd2
-  alpineVersion: 3.16.0
+  isoVersion: 0.2.26.rd2
+  alpineVersion: 3.17.0
 WSLDistro: "0.32"
 kuberlr: 0.4.2
 helm: 3.11.0

--- a/pkg/rancher-desktop/backend/kube/lima.ts
+++ b/pkg/rancher-desktop/backend/kube/lima.ts
@@ -368,7 +368,7 @@ export default class LimaKubernetesBackend extends events.EventEmitter implement
     const config: Record<string, string> = {
       PORT:            this.desiredPort.toString(),
       ENGINE:          cfg.kubernetes.containerEngine ?? ContainerEngine.NONE,
-      ADDITIONAL_ARGS: '',
+      ADDITIONAL_ARGS: `--node-ip ${ await this.vm.ipAddress }`,
       LOG_DIR:         paths.logs,
     };
 

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -397,33 +397,12 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     }
   }
 
-  /** Get the IPv4 address of the VM, assuming it's already up */
+  /**
+   * Get the IPv4 address of the VM, assuming it's already up.
+   * In Lima the slirp IP is hard-coded to 192.168.5.15.
+   */
   get ipAddress(): Promise<string | undefined> {
-    return (async() => {
-      // Get the routing map structure
-      const state = await this.execCommand({ capture: true }, 'cat', '/proc/net/fib_trie');
-
-      // We look for the IP address by:
-      // 1. Convert the structure (text) into lines.
-      // 2. Look for lines followed by "/32 host LOCAL".
-      //    This gives interface addresses.
-      const lines = state
-        .split(/\r?\n+/)
-        .filter((_, i, array) => (array[i + 1] || '').includes('/32 host LOCAL'));
-      // 3. Filter for lines with the shortest prefix; this is needed to reject
-      //    the CNI interfaces.
-      const lengths: [number, string][] = lines.map(line => [line.length - line.trimStart().length, line]);
-      const minLength = Math.min(...lengths.map(([length]) => length));
-      // 4. Drop the tree formatting ("    |-- ").  The result are IP addresses.
-      // 5. Reject loopback addresses.
-      const addresses = lengths
-        .filter(([length]) => length === minLength)
-        .map(([_, address]) => address.replace(/^\s+\|--/, '').trim())
-        .filter(address => !address.startsWith('127.'));
-
-      // Assume any of the addresses works to connect to the apiserver, so pick the first one.
-      return addresses[0];
-    })();
+    return Promise.resolve('192.168.5.15');
   }
 
   getBackendInvalidReason(): Promise<BackendError | null> {

--- a/pkg/rancher-desktop/components/BackendProgress.vue
+++ b/pkg/rancher-desktop/components/BackendProgress.vue
@@ -107,6 +107,10 @@ class BackendProgress extends Vue {
         this.progressDuration = '';
       }
     });
+
+    ipcRenderer.invoke('k8s-progress').then((progress) => {
+      this.progress = progress;
+    });
   }
 }
 export default BackendProgress;

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -94,6 +94,7 @@ export interface IpcMainInvokeEvents {
   'get-app-version': () => string;
   'show-message-box': (options: Electron.MessageBoxOptions) => Promise<Electron.MessageBoxReturnValue>;
   'api-get-credentials': () => { user: string, password: string, port: number, pid: number };
+  'k8s-progress': () => Readonly<{current: number, max: number, description?: string, transitionTime?: Date}>;
 
   // #region main/imageEvents
   'images-mounted': (mounted: boolean) => {imageName: string, tag: string, imageID: string, size: string}[];

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -1,0 +1,86 @@
+/**
+ * This script builds the distributable packages. It assumes that we have _just_
+ * built the JavaScript parts.
+ */
+
+'use strict';
+
+import childProcess from 'child_process';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+import buildInstaller from './lib/installer-win32';
+
+import { spawnFile } from '@pkg/utils/childProcess';
+
+/** Get the argument value (if any) for any of the given argument names */
+function getArgValue(args: string[], ...argNames: string[]): string | undefined {
+  for (const [i, arg] of args.entries()) {
+    const lowerArg = arg.toLowerCase();
+
+    for (const argName of argNames) {
+      if (argName === lowerArg && i < args.length - 1) {
+        return args[i + 1];
+      }
+      if (argName.startsWith('--')) {
+        // long arg, "--variable=foo"
+        if (lowerArg.startsWith(`${ argName }=`)) {
+          return lowerArg.substring(argName.length + 1);
+        }
+      } else if (lowerArg.startsWith(argName)) {
+        // short arg, "-vfoo"
+        return lowerArg.substring(argName.length);
+      }
+    }
+  }
+}
+
+class Builder {
+  async replaceInFile(srcFile: string, pattern: string | RegExp, replacement: string, dstFile?: string) {
+    dstFile = dstFile || srcFile;
+    await fs.stat(srcFile);
+    const data = await fs.readFile(srcFile, 'utf8');
+
+    await fs.writeFile(dstFile, data.replace(pattern, replacement));
+  }
+
+  async package() {
+    console.log('Packaging...');
+    const args = process.argv.slice(2).filter(x => x !== '--serial');
+    // On Windows, electron-builder will run the installer to generate the
+    // uninstall stub; however, we set the installer to be elevated, in order
+    // to ensure that we can install WSL if necessary.  To make it possible to
+    // build the installer as a non-administrator, we need to set the special
+    // environment variable `__COMPAT_LAYER=RunAsInvoker` to force the installer
+    // to run as the existing user.
+    const env = { ...process.env, __COMPAT_LAYER: 'RunAsInvoker' };
+    const fullBuildVersion = childProcess.execFileSync('git', ['describe', '--tags']).toString().trim();
+    const finalBuildVersion = fullBuildVersion.replace(/^v/, '');
+    const appData = 'packaging/linux/rancher-desktop.appdata.xml';
+    const release = `<release version="${ finalBuildVersion }" date="${ new Date().toISOString() }"/>`;
+
+    await this.replaceInFile(appData, /<release.*\/>/g, release, appData.replace('packaging', 'resources'));
+    args.push(`-c.extraMetadata.version=${ finalBuildVersion }`);
+    await spawnFile('node', ['node_modules/electron-builder/out/cli/cli.js', ...args], { stdio: 'inherit', env });
+
+    if (process.platform === 'win32') {
+      const distDir = path.join(process.cwd(), 'dist');
+      const appDir = path.join(distDir, 'win-unpacked');
+      const targetList = getArgValue(args, '-w', '--win', '--windows');
+
+      if (targetList !== 'zip') {
+        // Only build installer if we're not asked not to.
+        await buildInstaller(distDir, appDir);
+      }
+    }
+  }
+
+  async run() {
+    await this.package();
+  }
+}
+
+(new Builder()).run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
This makes it possible to only do a test build (without packaging for Electron).  To get the previous behaviour, run `npm run build` followed by `npm run package`.

This also ensures `npm run package -- --win=zip` no longer builds the Windows installer (as it used to).