### PR TITLE
GitHub workflows: enable yarn caching

### DIFF
--- a/.github/workflows/docker-cli-monitor.yaml
+++ b/.github/workflows/docker-cli-monitor.yaml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
+          cache: yarn
 
       - run: yarn install --frozen-lockfile
 

--- a/.github/workflows/macM1-e2e.yaml
+++ b/.github/workflows/macM1-e2e.yaml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
+          cache: yarn
       - uses: actions/setup-go@v4
         with:
           go-version: '^1.18'

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -39,6 +39,7 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: '16.x'
+        cache: yarn
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
@@ -159,6 +160,7 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: '16.x'
+        cache: yarn
       # Needs a network timeout for macos & windows. See https://github.com/yarnpkg/yarn/issues/8242 for more info
     - run: yarn install --frozen-lockfile --network-timeout 1000000
     - uses: actions/download-artifact@v3

--- a/.github/workflows/rddepman.yaml
+++ b/.github/workflows/rddepman.yaml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
+          cache: yarn
 
       - run: yarn install --frozen-lockfile
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,7 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: '16.x'
+        cache: yarn
     - uses: actions/setup-go@v4
       with:
         go-version: '^1.18'

--- a/.github/workflows/ucmonitor.yaml
+++ b/.github/workflows/ucmonitor.yaml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
+          cache: yarn
 
       - run: yarn install --frozen-lockfile
 

--- a/.github/workflows/upgrade-generate.yaml
+++ b/.github/workflows/upgrade-generate.yaml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: '16.x'
+        cache: yarn
     - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
@@ -87,6 +88,7 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: '16.x'
+        cache: yarn
     - run: yarn install --frozen-lockfile
     - name: Download installer (exe)
       id: exe

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '16.x'
-          cache: npm
+          cache: yarn
       - uses: actions/setup-go@v4
         with:
           go-version: '^1.18'


### PR DESCRIPTION
We previously disabled it because of issues on Windows with npm, but now that we switched to yarn it might work better (or it might not).