### PR TITLE
rddepman: bump helm from 3.16.0 to 3.17.2

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -6,7 +6,7 @@ alpineLimaISO:
   alpineVersion: 3.20.3
 WSLDistro: "0.78"
 kuberlr: 0.6.0
-helm: 3.16.0
+helm: 3.17.2
 dockerCLI: 28.0.1
 dockerBuildx: 0.22.0
 dockerCompose: 2.34.0


### PR DESCRIPTION

    <details>
    <summary><h2>Helm 3.16.1 (v3.16.1)</h2></summary>

    Helm v3.16.1 is a patch release. Users are encouraged to upgrade for the best experience. Users are encouraged to upgrade for the best experience.

This release fixes a regression that is in 3.16.0.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)

## Installation and Upgrading

Download Helm v3.16.1. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.16.1-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.1-darwin-amd64.tar.gz.sha256sum) / 1b194824e36da3e3889920960a93868b541c7888c905a06757e88666cfb562c9)
- [MacOS arm64](https://get.helm.sh/helm-v3.16.1-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.1-darwin-arm64.tar.gz.sha256sum) / 405a3b13f0e194180f7b84010dfe86689d7703e80612729882ad71e2a4ef3504)
- [Linux amd64](https://get.helm.sh/helm-v3.16.1-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.1-linux-amd64.tar.gz.sha256sum) / e57e826410269d72be3113333dbfaac0d8dfdd1b0cc4e9cb08bdf97722731ca9)
- [Linux arm](https://get.helm.sh/helm-v3.16.1-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.1-linux-arm.tar.gz.sha256sum) / a15a8ddfc373628b13cd2a987206756004091a1f6a91c3b9ee8de6f0b1e2ce90)
- [Linux arm64](https://get.helm.sh/helm-v3.16.1-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.1-linux-arm64.tar.gz.sha256sum) / 780b5b86f0db5546769b3e9f0204713bbdd2f6696dfdaac122fbe7f2f31541d2)
- [Linux i386](https://get.helm.sh/helm-v3.16.1-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.1-linux-386.tar.gz.sha256sum) / 92d7a47a90734b50528ffffc99cd1b2d4b9fc0f4291bac92c87ef03406a5a7b2)
- [Linux ppc64le](https://get.helm.sh/helm-v3.16.1-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.1-linux-ppc64le.tar.gz.sha256sum) / 9f0178957c94516eff9a3897778edb93d78fab1f76751bd282883f584ea81c23)
- [Linux s390x](https://get.helm.sh/helm-v3.16.1-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.1-linux-s390x.tar.gz.sha256sum) / 357f8b441cc535240f1b0ba30a42b44571d4c303dab004c9e013697b97160360)
- [Linux riscv64](https://get.helm.sh/helm-v3.16.1-linux-riscv64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.1-linux-riscv64.tar.gz.sha256sum) / 9a2cab45b7d9282e9be7b42f86d8034dcaa2e81ab338642884843676c2f6929f)
- [Windows amd64](https://get.helm.sh/helm-v3.16.1-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.16.1-windows-amd64.zip.sha256sum) / 89952ea1bace0a9498053606296ea03cf743c48294969dfc731e7f78d1dc809a)
- [Windows arm64](https://get.helm.sh/helm-v3.16.1-windows-arm64.zip) ([checksum](https://get.helm.sh/helm-v3.16.1-windows-arm64.zip.sha256sum) / fc370a291ed926da5e77acf42006de48e7fd5ff94d20c3f6aa10c04fea66e53c)

This release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina). Please use the attached signatures for verifying this release using `gpg`.

The [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://helm.sh/docs/intro/install/). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.16.2 is the next patch release and will be on October 09, 2024
- 3.17.0 is the next feature release and will be on January 15, 2025

## Changelog

- bumping version to 1.22.7 5a5449dc42be07001fd5771d56429132984ab3ab (Robert Sirchia)
- Merge pull request #13327 from mattfarina/revert-11726 2cbf7fc005885cb46b60ebfcd03ff09890e43be1 (Joe Julian)

    </details>
    


    <details>
    <summary><h2>Helm v3.16.2 (v3.16.2)</h2></summary>

    Helm v3.16.2 is a patch release. Users are encouraged to upgrade for the best experience. Users are encouraged to upgrade for the best experience.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)

## Installation and Upgrading

Download Helm v3.16.2. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.16.2-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.2-darwin-amd64.tar.gz.sha256sum) / 33efd48492f2358a49a231873e8baf41f702b5ab059333ae9c31e5517633c16e)
- [MacOS arm64](https://get.helm.sh/helm-v3.16.2-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.2-darwin-arm64.tar.gz.sha256sum) / 56413c7fbb496d2789881039cab61d849727c7b35db00826fae7a2685a403344)
- [Linux amd64](https://get.helm.sh/helm-v3.16.2-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.2-linux-amd64.tar.gz.sha256sum) / 9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb)
- [Linux arm](https://get.helm.sh/helm-v3.16.2-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.2-linux-arm.tar.gz.sha256sum) / f0f606d0806a518b749bd82e8dbfe6a803aa33340215590ef3977c60e366ba82)
- [Linux arm64](https://get.helm.sh/helm-v3.16.2-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.2-linux-arm64.tar.gz.sha256sum) / 1888301aeb7d08a03b6d9f4d2b73dcd09b89c41577e80e3455c113629fc657a4)
- [Linux i386](https://get.helm.sh/helm-v3.16.2-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.2-linux-386.tar.gz.sha256sum) / 4fb0cdf74a8a23622aac5980fbbc91cd95b08de5624ac0beba271d7b3b1a128d)
- [Linux ppc64le](https://get.helm.sh/helm-v3.16.2-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.2-linux-ppc64le.tar.gz.sha256sum) / 32a1b6073064a4a86d2a684180b6662ea202d1294b09ca52a6ba9d4cf071fec7)
- [Linux s390x](https://get.helm.sh/helm-v3.16.2-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.2-linux-s390x.tar.gz.sha256sum) / a2e80592b9e45487d8bb6b10721c759287cf18be4389b53d67c7cf1e91c84959)
- [Linux riscv64](https://get.helm.sh/helm-v3.16.2-linux-riscv64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.2-linux-riscv64.tar.gz.sha256sum) / c9730c8e6a1b2b30e119270793772bcac835737a16e613aabc36b07b8e027009)
- [Windows amd64](https://get.helm.sh/helm-v3.16.2-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.16.2-windows-amd64.zip.sha256sum) / 57821dd47d5728912e14000ee62262680e9039e8d05e18342cc010d5ac7908d7)
- [Windows arm64](https://get.helm.sh/helm-v3.16.2-windows-arm64.zip) ([checksum](https://get.helm.sh/helm-v3.16.2-windows-arm64.zip.sha256sum) / d746889023a6df98f71d2785835e32cd6fbbf81e21a21d5e9d4542ed3cfe168d)

This release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina). Please use the attached signatures for verifying this release using `gpg`.

The [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://helm.sh/docs/intro/install/). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.16.3 is the next patch release and will be on November 13, 2024
- 3.17.0 is the next feature release and will be on January 15, 2025

## Changelog

- Revering change unrelated to issue #13176 13654a52f7c70a143b1dd51416d633e1071faffb (ricardo.bartels@telekom.de)
- adds tests for handling of Helm index with broken chart versions #13176 9fc8f1b614e1a2f41afa36e081c89ead21cd63bb (ricardo.bartels@telekom.de)
- improves handling of Helm index with broken helm chart versions #13176 961194d85dd0c9d18492a99c9193faa7f1556968 (ricardo.bartels@telekom.de)
- Bump the k8s-io group with 7 updates f6be62b65a92c16927c24310885d01ecfb1d2aaf (dependabot[bot])
- adding check-latest:true 27d44cf4c9cbdb05aaed038e970263a5b11c0b51 (Robert Sirchia)
- Grammar fixes 46e0a0f9e44b56b0d2fc81cc0e624534662b1df7 (Nathan Baulch)
- Fix typos a1bd541d17cd6d120635c1f65ada92edcd224517 (Nathan Baulch)

    </details>
    


    <details>
    <summary><h2>Helm v3.16.3 (v3.16.3)</h2></summary>

    Helm v3.16.3 is a patch release. Users are encouraged to upgrade for the best experience. Users are encouraged to upgrade for the best experience.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)

## Installation and Upgrading

Download Helm v3.16.3. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.16.3-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.3-darwin-amd64.tar.gz.sha256sum) / 495d75b404a96fb664f1ca3f8cb01db2210aacc62dbfa1bbab30916abbb20a57)
- [MacOS arm64](https://get.helm.sh/helm-v3.16.3-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.3-darwin-arm64.tar.gz.sha256sum) / 3a39f690173086e6eea17674751eb3c8b970c02697e49cecd4093eaa3cf89dcd)
- [Linux amd64](https://get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.3-linux-amd64.tar.gz.sha256sum) / f5355c79190951eed23c5432a3b920e071f4c00a64f75e077de0dd4cb7b294ea)
- [Linux arm](https://get.helm.sh/helm-v3.16.3-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.3-linux-arm.tar.gz.sha256sum) / 02ba2f3b1524113f49be6df25a0b4b3190010d6e218c8e2b2fde4578a8439a9c)
- [Linux arm64](https://get.helm.sh/helm-v3.16.3-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.3-linux-arm64.tar.gz.sha256sum) / 5bd34ed774df6914b323ff84a0a156ea6ff2ba1eaf0113962fa773f3f9def798)
- [Linux i386](https://get.helm.sh/helm-v3.16.3-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.3-linux-386.tar.gz.sha256sum) / 70318f60fec3219680fff86c9293e2a92fb8b9a691d41791661074588f22768e)
- [Linux ppc64le](https://get.helm.sh/helm-v3.16.3-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.3-linux-ppc64le.tar.gz.sha256sum) / 266f7698c56a724fddd3a2f2b862ad496c4338dce79f0282fdbc6e23e1738608)
- [Linux s390x](https://get.helm.sh/helm-v3.16.3-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.3-linux-s390x.tar.gz.sha256sum) / bac414c409faead9c2b8af11d29281aa4f1aeb9139c62d5178baf982d71fc9bb)
- [Linux riscv64](https://get.helm.sh/helm-v3.16.3-linux-riscv64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.3-linux-riscv64.tar.gz.sha256sum) / 492843d2584bb14bd38a735a9708af2d7f3ea7e1b6c43e650968f16fce0b5064)
- [Windows amd64](https://get.helm.sh/helm-v3.16.3-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.16.3-windows-amd64.zip.sha256sum) / 1a52aa56e55168c3d3d2e45fa833a32290e4e3790559851dce1e707eb7728b81)
- [Windows arm64](https://get.helm.sh/helm-v3.16.3-windows-arm64.zip) ([checksum](https://get.helm.sh/helm-v3.16.3-windows-arm64.zip.sha256sum) / 247a63269a83bb73c14e8f62b0cfd5a2e1d32b7d3f93977d3a6ef3902d218ff1)

This release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina). Please use the attached signatures for verifying this release using `gpg`.

The [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://helm.sh/docs/intro/install/). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.16.4 is the next patch release and will be on December 11, 2024
- 3.17.0 is the next feature release and will be on January 15, 2025

## Changelog

- fix: fix label name cfd07493f46efc9debd9cc1b02a0961186df7fdf (wangjingcun)
- Fix typo in pkg/lint/rules/chartfile_test.go a303060fc60bc713cd0757503b3fcb4636b14f34 (Zach Burgess)
- Increasing the size of the runner used for releases. ab45e8a861e929e40163a7ad5a8636cb41f381ac (Matt Farina)
- fix(hooks): correct hooks delete order 19fe320ae87e8d1d4bc1952d9da8ea2fe435aa6e (Suleiman Dibirov)
- Bump github.com/containerd/containerd from 1.7.12 to 1.7.23 4fcc5c2cadf49d1399adfdbc5ab7222b2dff1d5b (dependabot[bot])
    </details>
    


    <details>
    <summary><h2>Helm v3.16.4 (v3.16.4)</h2></summary>

    Helm v3.16.4 is a patch release. Users are encouraged to upgrade for the best experience. Users are encouraged to upgrade for the best experience.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)

## Installation and Upgrading

Download Helm v3.16.4. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.16.4-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.4-darwin-amd64.tar.gz.sha256sum) / 8dc25671120a4af197afe7ad9041fb8e1dd71bc01e5ef73dba1139cbc9e9f44b)
- [MacOS arm64](https://get.helm.sh/helm-v3.16.4-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.4-darwin-arm64.tar.gz.sha256sum) / e2442d8f05d53d84c39b869bc5fe5affad247ee2f4c706a040919c146edb1f94)
- [Linux amd64](https://get.helm.sh/helm-v3.16.4-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.4-linux-amd64.tar.gz.sha256sum) / fc307327959aa38ed8f9f7e66d45492bb022a66c3e5da6063958254b9767d179)
- [Linux arm](https://get.helm.sh/helm-v3.16.4-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.4-linux-arm.tar.gz.sha256sum) / 432e774d1087d3773737888d384c62477b399227662b42cbf0c32e95e6e72556)
- [Linux arm64](https://get.helm.sh/helm-v3.16.4-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.4-linux-arm64.tar.gz.sha256sum) / d3f8f15b3d9ec8c8678fbf3280c3e5902efabe5912e2f9fcf29107efbc8ead69)
- [Linux i386](https://get.helm.sh/helm-v3.16.4-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.4-linux-386.tar.gz.sha256sum) / 6022b34e165a5196827043c77bcd1fa28ef48109b3a4af46e8660ddb0a6c44e0)
- [Linux ppc64le](https://get.helm.sh/helm-v3.16.4-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.4-linux-ppc64le.tar.gz.sha256sum) / 0ba4375a6dcf6117a8e7729fbed36d9220f8ad98dbc7aabc16186f22917caead)
- [Linux s390x](https://get.helm.sh/helm-v3.16.4-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.4-linux-s390x.tar.gz.sha256sum) / 10b88dc2afd97267feba8283d58dcb1c937defb7df8de152c86b60aaece47d59)
- [Linux riscv64](https://get.helm.sh/helm-v3.16.4-linux-riscv64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.16.4-linux-riscv64.tar.gz.sha256sum) / e733c727de7644cfeb25b094e1f0a56c53a7cb437c93c992aa92e6c7b9f6af93)
- [Windows amd64](https://get.helm.sh/helm-v3.16.4-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.16.4-windows-amd64.zip.sha256sum) / 9bb114c12e530a7129fd3d78fc1784e813dd7a6e29e5f9b5af8bc83fd1066d36)
- [Windows arm64](https://get.helm.sh/helm-v3.16.4-windows-arm64.zip) ([checksum](https://get.helm.sh/helm-v3.16.4-windows-arm64.zip.sha256sum) / a4afeee93031920ec08b7e880c859a159bcd222837a81196cadaeb42408ad0b3)

This release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina). Please use the attached signatures for verifying this release using `gpg`.

The [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://helm.sh/docs/intro/install/). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.17.0 is the next feature release and will be on January 15, 2025

## Changelog

- Bump golang.org/x/crypto from 0.30.0 to 0.31.0 7877b45b63f95635153b29a42c0c2f4273ec45ca (dependabot[bot])
- Bump the k8s-io group with 7 updates 848e586c27f05d84bc19d082f395098aba0b7619 (dependabot[bot])

    </details>
    


    <details>
    <summary><h2>v3.17.0-rc.1 (v3.17.0-rc.1)</h2></summary>

    Helm v3.17.0-rc.1 is a pre-release. It is to help gather feedback from the community as well as give users a chance to test Helm in staging environments before v3.17.0 is officially released.

The official changelog will come out with the v3.17.0 release. For now, you can see the commit changes from v3.16.4 [here](https://github.com/helm/helm/compare/v3.16.4...v3.17.0-rc.1).

## Installation and Upgrading

Download Helm v3.17.0-rc.1. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.17.0-rc.1-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-rc.1-darwin-amd64.tar.gz.sha256sum) / 954906de6554e0ec9360f4fb044489cc0385cca75a7d6448fc23167060c775c1)
- [MacOS arm64](https://get.helm.sh/helm-v3.17.0-rc.1-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-rc.1-darwin-arm64.tar.gz.sha256sum) / f45d4644183ced48912c08ffd7383f97a38e5398d2be1b707564f4d667395e0d)
- [Linux amd64](https://get.helm.sh/helm-v3.17.0-rc.1-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-rc.1-linux-amd64.tar.gz.sha256sum) / 35a11c999c9967ceaf67dcb630ebb784206252a26cb3cb036db0ef15bda329e2)
- [Linux arm](https://get.helm.sh/helm-v3.17.0-rc.1-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-rc.1-linux-arm.tar.gz.sha256sum) / 3247af04ed3ac15f8bdd0a8135dce128c8c68d3d95df37abb9050d95485b52d7)
- [Linux arm64](https://get.helm.sh/helm-v3.17.0-rc.1-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-rc.1-linux-arm64.tar.gz.sha256sum) / b2f0ee50a8673172cf173f949b9465825f734d7df5ad1458787dcf07b8e9ed49)
- [Linux i386](https://get.helm.sh/helm-v3.17.0-rc.1-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-rc.1-linux-386.tar.gz.sha256sum) / 0f7bd1c146c1a00252c4c6826e86285051163cac4d74a82480b29b3b3c56110b)
- [Linux ppc64le](https://get.helm.sh/helm-v3.17.0-rc.1-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-rc.1-linux-ppc64le.tar.gz.sha256sum) / 2554f302c5c969da43267c6d19d581667541e2e664912a2c0e69ef8386bcd056)
- [Linux s390x](https://get.helm.sh/helm-v3.17.0-rc.1-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-rc.1-linux-s390x.tar.gz.sha256sum) / 039305d33575f11e45ba946a3b5be9cdf4d4ff092388f2d18a8f9688161369aa)
- [Linux riscv64](https://get.helm.sh/helm-v3.17.0-rc.1-linux-riscv64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-rc.1-linux-riscv64.tar.gz.sha256sum) / 33a1631ae902fd34ae6d3e920042628efe69eeec8b2a7d362d312667c3cec836)
- [Windows amd64](https://get.helm.sh/helm-v3.17.0-rc.1-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.17.0-rc.1-windows-amd64.zip.sha256sum) / 62033ca49e3d1e764c0210546332b114699730e50a64bda08b83bb1d4ab65937)
- [Windows arm64](https://get.helm.sh/helm-v3.17.0-rc.1-windows-arm64.zip) ([checksum](https://get.helm.sh/helm-v3.17.0-rc.1-windows-arm64.zip.sha256sum) / dd740b5d81713f71e6fdce3d56b0582ea1a493cbd9ef9f3620c50331dea0bb9c)

This release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina). Please use the attached signatures for verifying this release using `gpg`.

    </details>
    


    <details>
    <summary><h2>Helm v3.17.0 (v3.17.0)</h2></summary>

    Helm v3.17.0 is a feature release. Users are encouraged to upgrade for the best experience.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)

## Notable Changes

- Allow pulling and installation by OCI digest
- Annotations and dependencies are now in chart metadata output
- New `--take-ownership` flag for install and upgrade commands
- SDK: Authorizer and registry authorizer are now configurable
- Removed the Kubernetes configuration file permissions check
- Added username/password to helm push and dependency build/update subcommands
- Added `toYamlPretty` template function

## Installation and Upgrading

Download Helm v3.17.0. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.17.0-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-darwin-amd64.tar.gz.sha256sum) / 0d5fd51cf51eb4b9712d52ecd8f2a3cd865680595cca57db38ee01802bd466ea)
- [MacOS arm64](https://get.helm.sh/helm-v3.17.0-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-darwin-arm64.tar.gz.sha256sum) / 5db292c69ba756ddbf139abb623b02860feef15c7f1a4ea69b77715b9165a261)
- [Linux amd64](https://get.helm.sh/helm-v3.17.0-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-linux-amd64.tar.gz.sha256sum) / fb5d12662fde6eeff36ac4ccacbf3abed96b0ee2de07afdde4edb14e613aee24)
- [Linux arm](https://get.helm.sh/helm-v3.17.0-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-linux-arm.tar.gz.sha256sum) / a388478049bf4ad440fa394f28421aa43cec3631ba197a8203c485edbec3e3fe)
- [Linux arm64](https://get.helm.sh/helm-v3.17.0-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-linux-arm64.tar.gz.sha256sum) / c4d4be8e80082b7eaa411e3e231d62cf05d01cddfef59b0d01006a7901e11ee4)
- [Linux i386](https://get.helm.sh/helm-v3.17.0-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-linux-386.tar.gz.sha256sum) / af89be03bb15175cd27573b48f4b9621e08982ab7788dd36e073baac988d6b2e)
- [Linux ppc64le](https://get.helm.sh/helm-v3.17.0-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-linux-ppc64le.tar.gz.sha256sum) / 32833acf72b240e9ca78a3eac630a0ba420e073b02df3030c369a287b8bdc769)
- [Linux s390x](https://get.helm.sh/helm-v3.17.0-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-linux-s390x.tar.gz.sha256sum) / 4b002d673ef35d78843c45cc169faf1040eec75937f19fccce41d2074f459653)
- [Linux riscv64](https://get.helm.sh/helm-v3.17.0-linux-riscv64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.0-linux-riscv64.tar.gz.sha256sum) / 38297aca2046fd13f2e0415ecc9cdb006f4008b286467f5f217187647dbbab5b)
- [Windows amd64](https://get.helm.sh/helm-v3.17.0-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.17.0-windows-amd64.zip.sha256sum) / 0625e51437107991922f76adbec4a4f12a4438942182677399ab758a3ec8bdc5)
- [Windows arm64](https://get.helm.sh/helm-v3.17.0-windows-arm64.zip) ([checksum](https://get.helm.sh/helm-v3.17.0-windows-arm64.zip.sha256sum) / 5fd16dde353aa5909562f127befea8db3879ecf63050fea3fb106ff8bfdd1a9c)

This release was signed with 208D D36E D5BB 3745 A167 43A4 C7C6 FBB5 B91C 1155  and can be found at @r6by [keybase account](https://keybase.io/r6by). Please use the attached signatures for verifying this release using gpg.

The [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://helm.sh/docs/intro/install/). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.17.1 is the next patch release and will be on February 12, 2025
- 3.18.0 is the next minor release and will be on May 14, 2025

## Changelog

- bump version to v3.17.0 301108edc7ac2a8ba79e4ebf5701b0b6ce6a31e4 (Matt Farina)
- fix: make ORAS reference private 949b2e604067a43797c640db4d6ed69af7aa3e5b (Terry Howe)
- fix: issue with helm template and oci chart aba95b9cb4827fe932e5eebabd55513333543d7c (Terry Howe)
- feat: allow installation by OCI digest c3e5217d85f37ba6adb570c3f2ff78dc7dfb343c (Terry Howe)
- Bump the k8s-io group with 7 updates 33a0ee7b9ac19d5578ef315cb4c220fe5ab069f1 (dependabot[bot])
- Upgrade golang.org/x/net to v0.33.0 to address CVE-2024-45338 79993d2e5bb05a1eba5978353db084f1ca9cb7ac (cx)
- Update golangci-lint version 037c18af3521c78cff41cfb84db01fb5847a98fb (Matt Farina)
- Update to Go 1.23 9f620b857a30ab377473ae626d68f3b3125ac928 (Matt Farina)
- ref(create): don't render empty resource fields ba180a3b6a82c8ae279e6cd51df78004c9de8a40 (dnskr)
- Add annotations and dependencies to get metadata output The output of helm get metadata includes a subset of the fields contained in the chart.Metadata struct. This change adds the values of the annotations field and the dependencies field to the output. 7321579092a5e84258c2f295031f175971700abe (Niladri Halder)
- Run `build-test` action on `dev-v3` branch 2042f7d35ab5bdd7a2090c8ed9b1e0881cc18aa2 (George Jenkins)
- Fix dev-v3 from take ownership changes a3a9e4f6432f7732f2e802962b8cea19c34817b8 (Matt Farina)
- Bump github.com/rubenv/sql-migrate from 1.7.0 to 1.7.1 c7cd1772c788c4ea84f2912479484da477d07195 (dependabot[bot])
- Bump github.com/cyphar/filepath-securejoin from 0.3.4 to 0.3.6 ca61226c0313de9bdbc6a3db25ebc6c3d7086428 (dependabot[bot])
- Bump github.com/stretchr/testify from 1.9.0 to 1.10.0 9421fac58f190bd1aca4b411614aed6098d5ed4a (dependabot[bot])
- Bump github.com/containerd/containerd from 1.7.23 to 1.7.24 562eb54fff03c9e8199500b78102ce6e00aa21b2 (dependabot[bot])
- Bump golang.org/x/crypto from 0.30.0 to 0.31.0 6ba4c6e000395403952c83668e47991139b656ad (dependabot[bot])
- Bump the k8s-io group with 7 updates ac162584190b898a12620b8b9a28a98a4c1e395b (dependabot[bot])
- fix test output edf7b66ae92b16f84d86fb98bc1508d66be7bcfb (Mayank Shah)
- fix test b9d58a19f1fdb58da7cb84370e60bcd29cc534f6 (Mayank Shah)
- fix upgrade 2541e465c402002a973682918ac8ee14bc8d7784 (Mayank Shah)
- Shadow ORAS remote.Client interface c40cf00a06b85d36856e0113733d385f38e02789 (George Jenkins)
- Make the authorizer and registry authorizer configurable 3c2ab912637234635a614cbc34b349fa21db7cc0 (Ryan Nowak)
- Rename CAFile to CaFile for consistency 7a22dd28d13b02c6cd15bea19c35825f4f420caf (Evans Mungai)
- Update cmd/helm/upgrade.go 885e938793203383abb9331b4a0662df85d2cbeb (Mayank Shah)
- Update cmd/helm/install.go 7efa2862ad48be335b5e2346f53db36bfe7bbcb2 (Mayank Shah)
- Add --take-ownership flag for install and upgrade commands c3a5f27c7742991a81c6bbc7bb8e15478f68a20d (Mayank Shah)
- Adding CI for dev-v3 branch b5a83ea8214b84cbe845319943ad641d91d02867 (Matt Farina)
- Bump golang.org/x/crypto from 0.28.0 to 0.29.0 a2d289f569786ab5ae81277c5d12cc83ce8aab41 (dependabot[bot])
- fix: fix label name e4062e7e000f54f6251c233329ef04f5d0799d59 (wangjingcun)
- Updating subchart load error to be more descriptive 6f2f7d4781752325ef8cd94d59caa73509ceeb84 (Taylor Jasko)
- Add tests to `helm/pkg/kube/client_test.go` to cover `wait.go` 9fd943b481ef7ca8126e78787b06ed0e2e854331 (Alex Johnson)
- Fix typo in pkg/lint/rules/chartfile_test.go 0cc78c6ac34790698d66d419f22531040a3bf738 (Zach Burgess)
- Increasing the size of the runner used for releases. 029e98324163aa7fd505bb8aab37337ef84d5830 (Matt Farina)
- fix(hooks): correct hooks delete order f4f4a6b81fbdb90412bd906fa5458482e94625bd (Suleiman Dibirov)
- Allow tests to run on loong64 a51ea6ec73f69c59ae13e228f27b006ad6efc54b (Tianle Xu)
- Bump actions/checkout from 4.2.1 to 4.2.2 f983342597dc5fc02bb3874956452186c3a7457a (dependabot[bot])
- Bump actions/setup-go from 5.0.2 to 5.1.0 c867af8e11c51af1aa00d1b2a56f0514fbf59e90 (dependabot[bot])
- chore: fix some function names in comment de9e138ec172c823788554f65710d103b9ac2388 (wangjingcun)
- Bump the k8s-io group with 7 updates e4304bd758aeaa8a620ed8b251e054617f2dfe1b (dependabot[bot])
- removing duplicate empty test 7e6b34d7dda28fa63b59ffdf6325cdf763dadf16 (Robert Sirchia)
- fixing unit test as per Matt 16a4e37f20910caa8830c223235a065029b8e8cb (Robert Sirchia)
- Ensure test fails without causing panic bdaa93b969f246119c4fd14267d286b041fb8f7f (Evans Mungai)
- Fix failing tests 3c4d0bb06138713bd009b3daf34f34a18a0850d7 (Evans Mungai)
- Remove unnecessary function arguments d25b0d9056fe1d7ff60280aa1c19f1771d687b9d (Evans Mungai)
- chore: Check tar is installed install script 3a5805ea7e8aa385cce278e0026656baa68fa83d (Evans Mungai)
- adding more unit test a205af755e4ab33109ebd728e4f58840c606029d (Robert Sirchia)
- Cleanup redundant GO11MODULE 4a15cc3385ade513ce28ca0c9f44440dab9627e2 (George Jenkins)
- adding test coverage for ready.go 999b85145aaa0c300dab69cdd7742699cf873ab2 (Robert Sirchia)
- fix(helm): Retry Conflict error for createResource, deleteResource 79a1f2c80117cc4d9db7c48d80a7fc76d3d479ca (Andreas Karis)
- minor spelling fix ca584648ee3776591d4d438c7a2d67310d35c424 (Jon Olsson)
- Bump github.com/containerd/containerd from 1.7.12 to 1.7.23 fe4d0d94da4e7f75f2f22f8449860c82756eb336 (dependabot[bot])
- Reorder triage ids 8b85934ec3a8cc41b21ff8f87f7f69f6f7553938 (Evans Mungai)
- chore: Add Evans to OWNERS file 75c124ade1f4ccdfa0e9faeca4d2e9df19195a73 (Evans Mungai)
- Bump github.com/cyphar/filepath-securejoin from 0.3.1 to 0.3.4 b45680c762228cd15bd82a3b6f4bc1b14a4893e9 (dependabot[bot])
- chore(deps): bump actions/stale from 3.0.14 to 9.0.0 140a376539dd52d8a0c1609da478adc26439aa23 (dependabot[bot])
- chore: Make retryingRoundTripper type public ab3c589809a163cb4227063c04da706e3a60ca2a (Luis Davim)
- Bump actions/checkout from 4.2.0 to 4.2.1 d517450a11ce7ce51445c34d354669895bd44bae (dependabot[bot])
- Doc: add Flox as an installation option. 30de3bbdc2b11172aa0028871ba9a7256c2f5b4c (Bryan Honof)
- Move jdolitsky to emeritus 076bb1fbd0296a69a701ac6c2ca704c1eba446cd (Josh Dolitsky)
- verbs f5fcae8356046a7b4861d231a2427dbf6e96b08c (George Jenkins)
- fix: Use chart archive modifed time for OCI push 02ef83fe28f123c57bdb3893740d64a63a01be22 (George Jenkins)
- Bump golang.org/x/crypto from 0.27.0 to 0.28.0 4c54d15a86677659143c4c734b412454f99a3917 (dependabot[bot])
- Revering change unrelated to issue #13176 cdbef2b7d1862e6fe4253e39740afbc5ec405679 (ricardo.bartels@telekom.de)
- Bump golangci/golangci-lint-action from 6.1.0 to 6.1.1 9e192b28ebadaea39bbfe7b35ab439c05b31e13b (dependabot[bot])
- updating owners file 36f0b42de383ad2de553291ee899531737e3f313 (Robert Sirchia)
- Bump the k8s-io group with 7 updates d5df06728363ac9c83d06e80fb3516c0714aa4d4 (dependabot[bot])
- Bump golang/govulncheck-action from 1.0.3 to 1.0.4 79257331c2ac1cccd142a0acbed230e7306e9e87 (dependabot[bot])
- Move gjenkins to maintainer 9c36d1f7b567c93348b6e2ecd4611a8742b26bfb (George Jenkins)
- Bump actions/checkout from 4.1.7 to 4.2.0 2cd8d54c83f7e8c7970d0876bb3d226f383be7d4 (dependabot[bot])
- fix: add missing formatChartName call de18ac16027201bb201c4cfe8736202d9feda8cd (Terry Howe)
- Update history.go 4735f2be9b7669e4f7a1bdf4a6dc4522c4bdfe64 (myeunee)
- adding toplevel permissions to workflows missing them a8750f4ce991b0aa3e40116091171afa5d359fed (Robert Sirchia)
- add strvals fuzzer from cncf-fuzzing b203cc17c85e47134dc553ec731e4ae5f21d7596 (Adam Korczynski)
- add chart fuzz tests e432f39ea727875284e578a380e176b61075cfb9 (Adam Korczynski)
- Remove the Kubernetes configuration file permissions check 49cb14a15ce9299a4c5cf2a51c4b97982276caba (Yarden Shoham)
- Grammar fixes ef85fa7f2ddc0a7a810007e283846c123f486748 (Nathan Baulch)
- Fix typos ff9dd262e394a48b689e3e1a33456dc18a1f4f47 (Nathan Baulch)
- removing testing trigger from govulncheck action 62069eb7b511e7480fd16271e5f0c5ce3455a3c6 (Robert Sirchia)
- adding top-level permissions 114db17898f942cff6529c4ac1075e66f8e3b5fe (Robert Sirchia)
- Fixing the action trigger 8642225be3ef801bca594f320240ed0218dd3166 (Robert Sirchia)
- testing permissing for codeql 5217ea8f18341c167e95f2fd01378edac4ba38f7 (Robert Sirchia)
- Bump ossf/scorecard-action from 2.3.1 to 2.4.0 9134b9edabb522a701429eb973b0b341e51f0b07 (dependabot[bot])
- Bump actions/checkout from 4.1.1 to 4.1.7 144e7b0287bdc6a61f92580f511db961f23ed22c (dependabot[bot])
- fix: fix testchart lint errors ddead08eb8e7e3fbbdbb6d40938dda36905789af (Rui Chen)
- adding check-latest:true 611fae3d7dbc4a0b48ea01739b5e67692911adc4 (Robert Sirchia)
- Revert "Improve helm dependency update performance" c81bd8912e67177f7941714098e762a88f04c430 (Matt Farina)
- bumping version to 1.22.7 e7b25bab6ff40ff3dcdeb498e6d74d1484a19215 (Robert Sirchia)
- Add New Relic a55c0b457d902af20ca0bb0da52a8cfa36ce6f7e (Calvin A. Allen)
- Update ADOPTERS.md 2b6f76c44e1eebcd90f89970aebd7b1c184a53d4 (Richard Hooper)
- Bump github.com/BurntSushi/toml from 1.3.2 to 1.4.0 06afebbedb40dfc837fcd23fded30ff986e0ace5 (dependabot[bot])
- Bump golang.org/x/crypto from 0.26.0 to 0.27.0 9f6925eb7fd74604ad23f1386b7382eed2b05b1d (dependabot[bot])
- refectoring to ONE GH action 5326d79d3e38449c85d8e1c951596a8616b3e2bc (Robert Sirchia)
- adding new lines at the end of each files d91188159e925672714a4ab634eceacb8d2a849c (Robert Sirchia)
- changing the trigger file 1aa640fe1d093cf8cb3a68825a5479c98d86f32a (Robert Sirchia)
- removing line break used for testing 0eae854a8562f3c13dd89481d2568ea0e6391f01 (Robert Sirchia)
- adding a line break to test the GH trigger 438221fbe3073df6e7bbf6473ab8e4e3763bcf6d (Robert Sirchia)
- changing trigger file from go.sum to go.mod 3ef6dd40367009230f136f549dc90464f090e770 (Robert Sirchia)
- removing govulncheck from build-test 5f15f53e2eb70973c82a606d67de98e859dff147 (Robert Sirchia)
- adding new workflows for govulncheck 4df7d5628b776a33f096516c89db7761de714b21 (Robert Sirchia)
- bump version to v3.16.0 d644da620521170086f024112bfa9439463fc995 (Matt Farina)
- Bump github.com/gofrs/flock from 0.8.1 to 0.12.1 a77ad1a4a2cd3efe9f119d43b76f77792c163a6d (dependabot[bot])
- adding a new line at the end of the file as per the request of the maintainers 88fa81ecb6cc11fd9aae95994bbb531da82e4d26 (Robert Sirchia)
- restoring the original triggers that were removed for testing 76b9d962f0633da44dd7afe466985b9bc67e39d0 (Robert Sirchia)
- moving govulncheck to a seperate job 38dd4a7fea06885510355bfaef5641a8a82073f4 (Robert Sirchia)
- removing specific go version for govulncheck 1ad6af92870acccae47f6bd25c2596baa2969e27 (Robert Sirchia)
- updating go version for govulncheck e46e0ddb9809485bf506e61b8720ff80e668b408 (Robert Sirchia)
- fixing directory for go-packages 6757f8a81b5f874633bf6138999dac13ed5e550b (Robert Sirchia)
- changing the triggers to test this GH actions 031b34458eca2832e7f402f4207e5a2da0c0f86d (Robert Sirchia)
- Adding in workflow_call to test GH Actions 7e3df4baafd58eefe960761be36bf2e1ecb36c83 (Robert Sirchia)
- adding workflow_dispatch to test b351fdce994b04084029cccb07f846ff723b274c (Robert Sirchia)
- adding govulncheck 67617290d4b826be94c829a95d909b216db2dfd5 (Robert Sirchia)
- fix: fixed the token-permission and pinned-dependencies issue b4caed94cd8e725d8c29c241dfd01c69aba95b33 (harshitasao)
- docs(repo_index): explicitly state that the result is written to the directory passed in a71eaeaf5223128727ba275a3e5f3d0e0c3e59e4 (Rauno Viskus)
- Added the scorecard github action and its badge ae17dea00da07e4447c392f26920935291305efd (harshitasao)
- Revert CAFile rename breaking change 0687961da4f708cd69c5cbde0f446b989671f0a5 (Evans Mungai)
- kube/client: add to global client-go scheme in init func b9bdeca93bf8d6e46b79ba4f4bcb029de3ec1a90 (Dr. Stefan Schimanski)
- adds tests for handling of Helm index with broken chart versions #13176 af13b0d8dca846ea27df3a21a4e37829e3b81654 (ricardo.bartels@telekom.de)
- improves handling of Helm index with broken helm chart versions #13176 154b47755403f5d9e13fdabdca62aff7b25a5acf (ricardo.bartels@telekom.de)
- Add username/password to package subcommand 12d8d28534644f1cad8be2c57c7d52e07f7b27c9 (Evans Mungai)
- Run go fmt 0ad80e3b58e7c4be56a0378bbd0b0a4cebd799a0 (Evans Mungai)
- Add username/password to dependency build/update subcommands 837ae4242cb58a96ed0129db3ca7fa1ff7a33ab5 (Evans Mungai)
- Add username/password to push subcommand 7672a1700d4dd85ae9885c8e443d673ef1d898ce (Evans Mungai)
- Update ADOPTERS.md e0751f34a755eed73cc88cdb8ba085d18e431a87 (Nick Josevski)
- ISSUE-9507: TEST server with varied Accept Header 3c39705212ae9800f6cc2d1996f877611c0d601d (Matt Clegg)
- ISSUE-9507: ADD `application/gzip,application/octet-stream` accept header when downloading chart fff3547f9c81a918dfcf3c34fad094323a5905b5 (Matt Clegg)
- test(create): Test to check deprecated resource templates 9c0b4c81211732e9f2866ecc08e3a0a147f80b62 (Bhargav Ravuri)
- added sprintf solution and found other possible overflow occurences ab640a71771f470861da46754dda668885f144f7 (Trenton VanderWert)
- changed Iota to FormatInt to allow int64 value preventing 2038 overflow 4a45342887abd2868536abc5ffdc8a711b8cfb87 (Trenton VanderWert)
- fix(helm): pass down username/password CLI parameters to OCI registry clients dc158f6208782b888fc5be6d23d8991042cf9f9c (Evans Mungai)
- Added `toYamlPretty` template function 73f1dcc1d9408504cd47f7efe1d04b277cf952b3 (Fred Heinecke)
- test(pkg/engine): add tests for TOML parsing 266ab5af0524bd42a2a7dcd80fd792f3f9574b5b (Dominik Müller)
- feat(pkg/engine): add TOML parsing functionality f550eda6e98e585cc66f8c7181531ca4a62ccf55 (Dominik Müller)
    </details>
    


    <details>
    <summary><h2>Helm v3.17.1 (v3.17.1)</h2></summary>

    Helm v3.17.1 is a patch release. Users are encouraged to upgrade for the best experience. Users are encouraged to upgrade for the best experience.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)

## Installation and Upgrading

Download Helm v3.17.1. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.17.1-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.1-darwin-amd64.tar.gz.sha256sum) / aba59ba9511971a71943b5c76f15d52ace1681197bb3f71ed1f0b15caceacb2c)
- [MacOS arm64](https://get.helm.sh/helm-v3.17.1-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.1-darwin-arm64.tar.gz.sha256sum) / b823a213d8d7937222becc63d9c7bb3d15a090e7ecd1f70f3a583ed39657e21b)
- [Linux amd64](https://get.helm.sh/helm-v3.17.1-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.1-linux-amd64.tar.gz.sha256sum) / 3b66f3cd28409f29832b1b35b43d9922959a32d795003149707fea84cbcd4469)
- [Linux arm](https://get.helm.sh/helm-v3.17.1-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.1-linux-arm.tar.gz.sha256sum) / 1dc5ed54350f4f7ae87441e878be4f4fd9b727a86b11b1d20b1001358c83bed3)
- [Linux arm64](https://get.helm.sh/helm-v3.17.1-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.1-linux-arm64.tar.gz.sha256sum) / c86c9b23602d4abbfae39d9634e25ab1d0ea6c4c16c5b154113efe316a402547)
- [Linux i386](https://get.helm.sh/helm-v3.17.1-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.1-linux-386.tar.gz.sha256sum) / b972562a1171673db2892f000248b2540ddcd6f76850ec152852a8e9ce7972cb)
- [Linux ppc64le](https://get.helm.sh/helm-v3.17.1-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.1-linux-ppc64le.tar.gz.sha256sum) / 4223394f3fca82a7f8e8d083caf6faf0ee0639d8f235071334579237078a2c2e)
- [Linux s390x](https://get.helm.sh/helm-v3.17.1-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.1-linux-s390x.tar.gz.sha256sum) / fe47e5ee8abd6baef01bb1c4fc995343121bf5fc7dead1f67e97484a441ba9e8)
- [Linux riscv64](https://get.helm.sh/helm-v3.17.1-linux-riscv64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.1-linux-riscv64.tar.gz.sha256sum) / cf174b1ff83032255f798278152c637d01dd1d1533fd77915ab751d8cf4191a7)
- [Windows amd64](https://get.helm.sh/helm-v3.17.1-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.17.1-windows-amd64.zip.sha256sum) / 08281ee6d4d272835ff10c510b8b39736d112d9cb89dfbc853fe83913fbe48d0)
- [Windows arm64](https://get.helm.sh/helm-v3.17.1-windows-arm64.zip) ([checksum](https://get.helm.sh/helm-v3.17.1-windows-arm64.zip.sha256sum) / 44c9c8246f643ea45bb45013a182fc25da2a8206a6f322a0c6fa47a1f4bcf1e4)

The [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://helm.sh/docs/intro/install/). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.17.2 is the next patch release and will be on March 12, 2025
- 3.18.0 is the next minor release and will be on May 14, 2025

## Changelog

- add test for nullifying nested global value 980d8ac1939e39138101364400756af2bdee1da5 (Ryan Hockstad)
- Add test case for removing an entire object c23e3b6c495658bb1eec04b32c8e4bfc5ef4dd60 (Ryan Hockstad)
- Tests for bugfix: Override subcharts with null values #12879 3110d5ff63a0edcf6decac8288106b55a6f41760 (Scott Rigby)
- merge null child chart objects 9520c71fb04783cdab111759f0f3c5d1cdc83f1c (Ryan Hockstad)
- build(deps): bump the k8s-io group with 7 updates ab7dedd4cf47cb7455a283d93a1627a35933d634 (dependabot[bot])
- fix: check group for resource info match a2d36029d5dba292073d23acea2ef59cfb429ee9 (Jiasheng Zhu)
    </details>
    


    <details>
    <summary><h2>Helm v3.17.2 (v3.17.2)</h2></summary>

    Helm v3.17.2 is a patch release. Users are encouraged to upgrade for the best experience. Users are encouraged to upgrade for the best experience.

The community keeps growing, and we'd love to see you there!

- Join the discussion in [Kubernetes Slack](https://kubernetes.slack.com):
  -  for questions and just to hang out
  -  for discussing PRs, code, and bugs
- Hang out at the Public Developer Call: Thursday, 9:30 Pacific via [Zoom](https://zoom.us/j/696660622)
- Test, debug, and contribute charts: [ArtifactHub/packages](https://artifacthub.io/packages/search?kind=0)

## Installation and Upgrading

Download Helm v3.17.2. The common platform binaries are here:

- [MacOS amd64](https://get.helm.sh/helm-v3.17.2-darwin-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.2-darwin-amd64.tar.gz.sha256sum) / 3e240238c7a3a10efd37b8e16615b28e94ba5db5957247bb42009ba6d52f76e9)
- [MacOS arm64](https://get.helm.sh/helm-v3.17.2-darwin-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.2-darwin-arm64.tar.gz.sha256sum) / b843cebcbebc9eccb1e43aba9cca7693d32e9f2c4a35344990e3b7b381933948)
- [Linux amd64](https://get.helm.sh/helm-v3.17.2-linux-amd64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.2-linux-amd64.tar.gz.sha256sum) / 90c28792a1eb5fb0b50028e39ebf826531ebfcf73f599050dbd79bab2f277241)
- [Linux arm](https://get.helm.sh/helm-v3.17.2-linux-arm.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.2-linux-arm.tar.gz.sha256sum) / 0b13ec8580dd5498b5a2d7cb34146e098049f59500a266db1bb98f59649eb90a)
- [Linux arm64](https://get.helm.sh/helm-v3.17.2-linux-arm64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.2-linux-arm64.tar.gz.sha256sum) / d78d76ec7625a94991e887ac049d93f44bd70e4876200b945f813c9e1ed1df7c)
- [Linux i386](https://get.helm.sh/helm-v3.17.2-linux-386.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.2-linux-386.tar.gz.sha256sum) / 1c599c4559b97d8cf2100704f5cdc3269dcb369b553711b09a564e1d89c725dc)
- [Linux ppc64le](https://get.helm.sh/helm-v3.17.2-linux-ppc64le.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.2-linux-ppc64le.tar.gz.sha256sum) / 6bb1c83078bdd5e9acad5793dfc9ab3b5b56d410723a660ff1da61dbdff3207b)
- [Linux s390x](https://get.helm.sh/helm-v3.17.2-linux-s390x.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.2-linux-s390x.tar.gz.sha256sum) / 55ce412c48a79020a435eed2d7895e3cf74293d939da60a287c7c5fc15480f58)
- [Linux riscv64](https://get.helm.sh/helm-v3.17.2-linux-riscv64.tar.gz) ([checksum](https://get.helm.sh/helm-v3.17.2-linux-riscv64.tar.gz.sha256sum) / 70e27a5b73fe848233f3e43bbe393a84d5ccfea2db666906ed37ef9b54468876)
- [Windows amd64](https://get.helm.sh/helm-v3.17.2-windows-amd64.zip) ([checksum](https://get.helm.sh/helm-v3.17.2-windows-amd64.zip.sha256sum) / f76fe76fa116d2bae948aee9bb54ba11bf5b726a09f732ce6a74eb65af2886b1)
- [Windows arm64](https://get.helm.sh/helm-v3.17.2-windows-arm64.zip) ([checksum](https://get.helm.sh/helm-v3.17.2-windows-arm64.zip.sha256sum) / a47a0059285347d44c2ac81aa09398cfa527eb60bcddd7e1836f9459e503697d)

This release was signed with `672C 657B E06B 4B30 969C 4A57 4614 49C2 5E36 B98E ` and can be found at @mattfarina [keybase account](https://keybase.io/mattfarina). Please use the attached signatures for verifying this release using `gpg`.

The [Quickstart Guide](https://helm.sh/docs/intro/quickstart/) will get you going from there. For **upgrade instructions** or detailed installation notes, check the [install guide](https://helm.sh/docs/intro/install/). You can also use a [script to install](https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3) on any system with `bash`.

## What's Next

- 3.17.3 is the next patch release and will be on April 09, 2025
- 3.18.0 is the next minor release and will be on May 14, 2025

## Changelog

- Updating to 0.37.0 for x/net cc0bbbd6d6276b83880042c1ecb34087e84d41eb (Matt Farina)
- build(deps): bump the k8s-io group with 7 updates ecb7a74f19c23f76e7c18d1ce99f88bf1926a9ae (dependabot[bot])

    </details>
    