### PR TITLE
-

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -9,7 +9,7 @@ kuberlr: 0.6.0
 helm: 3.17.3
 dockerCLI: 28.1.0
 dockerBuildx: 0.23.0
-dockerCompose: 2.35.1
+dockerCompose: 2.36.0
 golangci-lint: 2.1.2
 trivy: 0.61.0
 steve: 0.1.0-beta9


### PR DESCRIPTION
## v2.36.0 (v2.36.0)
## What's Changed

🎉 You can now use external binaries as service provider to extend Compose behaviour. For more information about creating your own plugin check [the documentation](https://github.com/docker/compose/blob/main/docs/extension.md)

### ✨ Improvements
* Introduce `networks.interface_name` by @ndeloof in https://github.com/docker/compose/pull/12771
* Add support for `COMPOSE_PROGRESS` env variable by @AnvarU in https://github.com/docker/compose/pull/12769
* Document extensibility using service.provider and open provider to external binaries by @ndeloof in https://github.com/docker/compose/pull/12777
* Introduce build `--check` by @ndeloof in https://github.com/docker/compose/pull/12765

### 🐛 Fixes
* Build: write `--print` output to stdout by @emersion in https://github.com/docker/compose/pull/12756
* Fix: concurrent map writes when pulling by @skanehira in https://github.com/docker/compose/pull/12752
* Fix support for remote absolute path by @ndeloof in https://github.com/docker/compose/pull/12786
* Fix collect image digests for service images built by bake by @ndeloof in https://github.com/docker/compose/pull/12784
* Enable services implicitly declared by a service:xx build dependency by @ndeloof in https://github.com/docker/compose/pull/12785
* Fix config `--variables` not honoring the `--format` flag by @alessio-perugini in https://github.com/docker/compose/pull/12809

### 🔧  Internal
* Remove support of Synchronize File Shares integration with Docker Desktop by @glours in https://github.com/docker/compose/pull/12763
* Display proper event message for provider services on up and down by @glours in https://github.com/docker/compose/pull/12788
* E2e test for start_interval by @ndeloof in https://github.com/docker/compose/pull/12795
* Document behavior on missing extension by @ndeloof in https://github.com/docker/compose/pull/12802

### ⚙️ Dependencies
* Build(deps): bump github.com/docker/cli from `28.1.0+incompatible` to `28.1.1+incompatible` by @dependabot in https://github.com/docker/compose/pull/12761
* Build(deps): bump github.com/docker/docker from `28.1.0+incompatible` to `28.1.1+incompatible` by @dependabot in https://github.com/docker/compose/pull/12759
* Build(deps): bump google.golang.org/grpc from `1.71.1` to `1.72.0` by @dependabot in https://github.com/docker/compose/pull/12760
* Build(deps): bump github.com/containerd/containerd/v2 from `2.0.4` to `2.0.5` by @dependabot in https://github.com/docker/compose/pull/12758
* Bump compose-go to `v2.6.1` by @glours in https://github.com/docker/compose/pull/12766
* Bump compose-go to `v2.6.2` by @glours in https://github.com/docker/compose/pull/12810
* Build(deps): bump github.com/moby/buildkit from `0.21.0` to `0.21.1` by @dependabot in https://github.com/docker/compose/pull/12796
* Build(deps): bump golang.org/x/sync from `0.13.0` to `0.14.0` by @dependabot in https://github.com/docker/compose/pull/12805
* Build(deps): bump golang.org/x/sys from `0.32.0` to `0.33.0` by @dependabot in https://github.com/docker/compose/pull/12804
* Build(deps): bump go.uber.org/mock from `0.5.1` to `0.5.2` by @dependabot in https://github.com/docker/compose/pull/12792


## New Contributors
* @skanehira made their first contribution in https://github.com/docker/compose/pull/12752
* @AnvarU made their first contribution in https://github.com/docker/compose/pull/12769
* @alessio-perugini made their first contribution in https://github.com/docker/compose/pull/12809

**Full Changelog**: https://github.com/docker/compose/compare/v2.35.1...v2.36.0
[Compare between v2.35.1 and v2.36.0](https://github.com/docker/compose/compare/v2.35.1...v2.36.0)
