### PR TITLE
-

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -10,7 +10,7 @@ helm: 3.17.3
 dockerCLI: 28.1.0
 dockerBuildx: 0.23.0
 dockerCompose: 2.35.1
-golangci-lint: 2.1.2
+golangci-lint: 2.1.6
 trivy: 0.61.0
 steve: 0.1.0-beta9
 rancherDashboard: 2.11.0.rd2


### PR DESCRIPTION
<details>
<summary><h3>v2.1.3 (v2.1.3)</h3></summary>

`golangci-lint` is a free and open-source project built by volunteers.

If you value it, consider supporting us, the [maintainers](https://opencollective.com/golangci-lint) and [linter authors](https://golangci-lint.run/product/thanks/).

We appreciate it! :heart:

For key updates, see the [changelog](https://golangci-lint.run/product/changelog/#213).

## Changelog
* 6d2a94be6b20f1c06e95d79479c6fdc34a69c45f build(deps): bump go.augendre.info/fatcontext from 0.7.2 to 0.8.0 (#5757)
* f1e4d89b5b2cf524e0aa095173c7ec4145eebb68 fix: add go.mod hash to the cache salt (#5739)
* d0588f0b92414cf65930b33e1b197428600a6359 fix: convert uint as pointer of uint for the migration (#5755)
* 43e07c47273e04c4d721ce3fef80562ab3333959 fix: order of staticcheck settings during migration (#5741)
* 221803a464609c9c6454ff56752854260e4715f6 fix: related information position (#5746)


</details>

[Compare between v2.1.2 and v2.1.3](https://github.com/golangci/golangci-lint/compare/v2.1.2...v2.1.3)
<details>
<summary><h3>v2.1.4 (v2.1.4)</h3></summary>

`golangci-lint` is a free and open-source project built by volunteers.

If you value it, consider supporting us, the [maintainers](https://opencollective.com/golangci-lint) and [linter authors](https://golangci-lint.run/product/thanks/).

We appreciate it! :heart:

For key updates, see the [changelog](https://golangci-lint.run/product/changelog/#214).

## Changelog

Due to an error related to Snapcraft, some artifacts of the v2.1.3 release have not been published.

This release contains the same things as v2.1.3.

</details>

[Compare between v2.1.3 and v2.1.4](https://github.com/golangci/golangci-lint/compare/v2.1.3...v2.1.4)
<details>
<summary><h3>v2.1.5 (v2.1.5)</h3></summary>

`golangci-lint` is a free and open-source project built by volunteers.

If you value it, consider supporting us, the [maintainers](https://opencollective.com/golangci-lint) and [linter authors](https://golangci-lint.run/product/thanks/).

We appreciate it! :heart:

For key updates, see the [changelog](https://golangci-lint.run/product/changelog/#215).

## Changelog

Due to an error related to Snapcraft, some artifacts of the v2.1.4 release have not been published.

This release contains the same things as v2.1.3.

</details>

[Compare between v2.1.4 and v2.1.5](https://github.com/golangci/golangci-lint/compare/v2.1.4...v2.1.5)
<details>
<summary><h3>v2.1.6 (v2.1.6)</h3></summary>

`golangci-lint` is a free and open-source project built by volunteers.

If you value it, consider supporting us, the [maintainers](https://opencollective.com/golangci-lint) and [linter authors](https://golangci-lint.run/product/thanks/).

We appreciate it! :heart:

For key updates, see the [changelog](https://golangci-lint.run/product/changelog/#216).

## Changelog
* 896c0417487bfc7ab34c328dded269e5c4e1acc9 build(deps): bump github.com/alecthomas/chroma/v2 from 2.16.0 to 2.17.0 (#5772)
* 75865b1cbd423e9529ed5ff3e1ec6f6aeec1fb86 build(deps): bump github.com/alecthomas/chroma/v2 from 2.17.0 to 2.17.2 (#5779)
* 999631accee0624ba7f17e3f754455d02e2c79aa build(deps): bump github.com/shirou/gopsutil/v4 from 4.25.3 to 4.25.4 (#5778)
* 1b791de9afa9dfae80a029ed2141918063b26c20 build(deps): bump github.com/tetafro/godot from 1.5.0 to 1.5.1 (#5770)
* 69778fe6e7f8c8c6d211be3d105a645352267d79 build(deps): bump go-simpler.org/musttag from 0.13.0 to 0.13.1 (#5769)
* 2ea61ac0ae9adeddc5551e444eb2c852df09e941 build(deps): bump the linter-testdata group across 2 directories with 2 updates (#5777)


</details>

[Compare between v2.1.5 and v2.1.6](https://github.com/golangci/golangci-lint/compare/v2.1.5...v2.1.6)