### PR TITLE
-

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -11,7 +11,7 @@ dockerCLI: 28.1.0
 dockerBuildx: 0.23.0
 dockerCompose: 2.35.1
 golangci-lint: 2.1.2
-trivy: 0.61.0
+trivy: 0.62.1
 steve: 0.1.0-beta9
 rancherDashboard: 2.11.0.rd2
 dockerProvidedCredentialHelpers: 0.9.3


### PR DESCRIPTION
<details>
<summary><h3>v0.61.1 (v0.61.1)</h3></summary>

## Changelog
* 7d3b4ffdd6b22ae80215f3a04421606b1f78de6a release: v0.61.1 [release/v0.61] (#8704)
* 80d120fa0f96695e09eb97f43fb7413e5c773e50 fix(k8s): skip passed misconfigs for the summary report [backport: release/v0.61] (#8748)
* 9d6290b31977b1bd4ab47349cd26498bc3b079c3 fix(k8s): correct compare artifact versions [backport: release/v0.61] (#8699)
* 3799ebbb5a9bc78041492d1f191fb94ce1aa389b test: use `aquasecurity` repository for test images [backport: release/v0.61] (#8698)


</details>

[Compare between v0.61.0 and v0.61.1](https://github.com/aquasecurity/trivy/compare/v0.61.0...v0.61.1)
<details>
<summary><h3>v0.62.0 (v0.62.0)</h3></summary>

## ⚡Release highlights and summary⚡

👉 https://github.com/aquasecurity/trivy/discussions/8801

## Changelog

https://github.com/aquasecurity/trivy/blob/main/CHANGELOG.md#0620-2025-04-30
</details>

[Compare between v0.61.1 and v0.62.0](https://github.com/aquasecurity/trivy/compare/v0.61.1...v0.62.0)
<details>
<summary><h3>v0.62.1 (v0.62.1)</h3></summary>

## Changelog
* c75ed2156c8fa801d6998016f46f6b953e8a9556 release: v0.62.1 [release/v0.62] (#8825)
* aafebeb53aecbc9ed1ea44f8601183b4c25c49e3 chore(deps): bump the common group across 1 directory with 10 updates [backport: release/v0.62] (#8831)
* 99485cfea2de53570342901eac860afdaacce86f fix(misconf): check if for-each is known when expanding dyn block [backport: release/v0.62] (#8826)
* b4fc9e8ca1ff77a2795ffa47d0fc53cecd0e1bbd fix(redhat): trim invalid suffix from content_sets in manifest parsing [backport: release/v0.62] (#8824)


</details>

[Compare between v0.62.0 and v0.62.1](https://github.com/aquasecurity/trivy/compare/v0.62.0...v0.62.1)