### PR TITLE
-

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -22,7 +22,7 @@ hostSwitch: 1.2.7
 moproxy: 0.5.1
 spinShim: 0.19.0
 spinOperator: 0.5.0
-certManager: 1.17.1
+certManager: 1.17.2
 spinCLI: 3.2.0
 spinKubePlugin: 0.4.0
 check-spelling: 0.0.24


### PR DESCRIPTION
## v1.17.2 (v1.17.2)
cert-manager is the easiest way to automatically manage certificates in Kubernetes and OpenShift clusters.

This patch release addresses several vulnerabilities reported by the Trivy security scanner. It is built with the latest version of Go 1.23 and includes various dependency updates. 

> 📖 Read the full [cert-manager 1.17 release notes](https://cert-manager.io/docs/releases/release-notes/release-notes-1.17), before installing or upgrading.

## Changes since `v1.17.1`

### Bug or Regression

- Bump Go to `v1.23.8` to fix `CVE-2025-22871` ([#7701](https://github.com/cert-manager/cert-manager/pull/7701), [`@wallrj`](https://github.com/wallrj))
- Bump `go-jose` dependency to address `CVE-2025-27144` ([#7603](https://github.com/cert-manager/cert-manager/pull/7603), [`@SgtCoDFish`](https://github.com/SgtCoDFish))
- Bump `golang.org/x/net` to address `CVE-2025-22870` reported by Trivy ([#7622](https://github.com/cert-manager/cert-manager/pull/7622), [`@SgtCoDFish`](https://github.com/SgtCoDFish))
- Bump `golang.org/x/net` to fix `CVE-2025-22872` ([#7703](https://github.com/cert-manager/cert-manager/pull/7703), [`@wallrj`](https://github.com/wallrj))
- Bump `golang.org/x/oauth2` to patch `CVE-2025-22868` ([#7692](https://github.com/cert-manager/cert-manager/pull/7692), [`@lentzi90`](https://github.com/lentzi90))
- Bump `golang.org/x/crypto` to patch `GHSA-hcg3-q754-cr77` ([#7692](https://github.com/cert-manager/cert-manager/pull/7692), [`@lentzi90`](https://github.com/lentzi90))
- Bump `github.com/golang-jwt/jwt` to patch `GHSA-mh63-6h87-95cp` ([#7692](https://github.com/cert-manager/cert-manager/pull/7692), [`@lentzi90`](https://github.com/lentzi90))
[Compare between v1.17.1 and v1.17.2](https://github.com/cert-manager/cert-manager/compare/v1.17.1...v1.17.2)
