### PR TITLE
rddepman: bump dockerCLI from 28.1.0 to 28.1.1

### DIFF
--- a/pkg/rancher-desktop/assets/dependencies.yaml
+++ b/pkg/rancher-desktop/assets/dependencies.yaml
@@ -7,7 +7,7 @@ alpineLimaISO:
 WSLDistro: "0.81"
 kuberlr: 0.6.0
 helm: 3.17.3
-dockerCLI: 28.1.0
+dockerCLI: 28.1.1
 dockerBuildx: 0.23.0
 dockerCompose: 2.35.1
 golangci-lint: 2.1.2


### PR DESCRIPTION
## Docker CLI builds for docker v28.1.1 (v28.1.1)
Docker CLI builds for docker v28.1.1

## What's Changed
* CI: Bump actions by @mook-as in https://github.com/rancher-sandbox/rancher-desktop-docker-cli/pull/10


**Full Changelog**: https://github.com/rancher-sandbox/rancher-desktop-docker-cli/compare/v25.0.1...v28.1.1
[Compare between v28.1.0 and v28.1.1](https://github.com/rancher-sandbox/rancher-desktop-docker-cli/compare/v28.1.0...v28.1.1)
